### PR TITLE
chore: Removed Axios module for `search_bar_container.js`

### DIFF
--- a/app/components/google_maps_modal_component.js
+++ b/app/components/google_maps_modal_component.js
@@ -88,10 +88,10 @@ export default class GMap_Modal extends Component {
 // export default connect(mapStateToProps)(JobDetail);
 
 function mapStateToProps(state) {
-  console.log("Maps: ", state.jobs.map(job => [job.latitude, job.longitude]));
+  console.log("Maps:", state.jobs.map(job => [job.latitude, job.longitude]));
   return {
     markers: state.jobs.map(job => new google.maps.LatLng(job.latitude, job.longitude)),
-    isModalOpen: state
+    isModalOpen: state.toggleModal
   };
 }
 

--- a/app/containers/search_bar_container.js
+++ b/app/containers/search_bar_container.js
@@ -2,7 +2,6 @@ import React, { Component, PropTypes } from 'react';
 import { Router, Route, hashHistory } from 'react-router';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import axios from 'axios';
 
 import { fetchJobs } from '../actions/index';
 

--- a/server/controllers/getRestaurant.js
+++ b/server/controllers/getRestaurant.js
@@ -4,7 +4,7 @@ const redisClient = require('redis').createClient;
 const redis = redisClient(6379, 'localhost');
 
 exports.post = (req, res) => {
-  let restaurant = 'restaurant', 
+  let restaurant = req.body.restaurant, 
       city = req.body.city, 
       coordinate = req.body.coordinate;
   // Create key based on request body to use for caching


### PR DESCRIPTION
- Minor quickfix: Removed the now-unnecessary `axios` module from the `search_bar_container.js` file in the `app/containers` subdirectory
