### PR TITLE
Feat(init): Pre-populate job body info

### DIFF
--- a/app/components/results_page.js
+++ b/app/components/results_page.js
@@ -67,7 +67,7 @@ export default class Results extends Component {
 
 let mapStateToProps = (state) => ({ jobs: state.jobs });
 
-let mapDispatchToProps = (dispatch) =>  {  // Whenever loadJobs is called, the result should be passed to all reducers:
+let mapDispatchToProps = (dispatch) =>  { 
   return bindActionCreators({ selectJob: selectJob , fetchYelp: fetchYelp, fetchGPlaces: fetchGPlaces}, dispatch);
 };
 

--- a/app/components/results_page.js
+++ b/app/components/results_page.js
@@ -67,13 +67,8 @@ export default class Results extends Component {
 
 let mapStateToProps = (state) => ({ jobs: state.jobs });
 
-// Anything returned from this function will end up as props on Joblist container
-// We now have an action thats going to change the state of our DOM. We need to 
-// notify all containers of the action that can be triggered
-let mapDispatchToProps = (dispatch) =>  {
-  // Whenever loadJobs is called, the result should be passed to all reducers:
+let mapDispatchToProps = (dispatch) =>  {  // Whenever loadJobs is called, the result should be passed to all reducers:
   return bindActionCreators({ selectJob: selectJob , fetchYelp: fetchYelp, fetchGPlaces: fetchGPlaces}, dispatch);
 };
 
-// Promote JobList to a container:
 export default connect(mapStateToProps, mapDispatchToProps)(Results);

--- a/app/components/results_page.js
+++ b/app/components/results_page.js
@@ -1,4 +1,7 @@
 import React, {Component} from 'react';
+import { connect } from 'react-redux';
+import { selectJob, fetchYelp, fetchGPlaces } from '../actions/index';
+import { bindActionCreators } from 'redux';
 
 import Banner from './banner_component';
 import DataDiagram from './diagram_component';
@@ -12,6 +15,26 @@ import PlacesList from '../containers/places_list_container';
 
 
 export default class Results extends Component {
+  constructor(props) {
+    super(props);
+
+    this.initJob = this.initJob.bind(this);
+  }
+
+  componentDidUpdate(nextProps) {
+    console.log('logging in componentWillReceiveProps');
+    console.log('jobs:', this.props.jobs);
+    if (this.props.jobs.length > 0) {
+     this.initJob(this.props.jobs[0]);
+    }
+  }
+
+  initJob(job) {
+    this.props.selectJob(job);
+    this.props.fetchYelp(job.city, job.latitude, job.longitude);
+    this.props.fetchGPlaces(job.latitude, job.longitude);
+  }
+
   render() {
     return (
       <div>
@@ -40,3 +63,17 @@ export default class Results extends Component {
     );
   }
 };
+
+
+let mapStateToProps = (state) => ({ jobs: state.jobs });
+
+// Anything returned from this function will end up as props on Joblist container
+// We now have an action thats going to change the state of our DOM. We need to 
+// notify all containers of the action that can be triggered
+let mapDispatchToProps = (dispatch) =>  {
+  // Whenever loadJobs is called, the result should be passed to all reducers:
+  return bindActionCreators({ selectJob: selectJob , fetchYelp: fetchYelp, fetchGPlaces: fetchGPlaces}, dispatch);
+};
+
+// Promote JobList to a container:
+export default connect(mapStateToProps, mapDispatchToProps)(Results);

--- a/app/containers/places_list_container.js
+++ b/app/containers/places_list_container.js
@@ -6,7 +6,7 @@ class PlacesList extends Component {
     return this.props.activePlaces.map((place) => {
       return (
         <li className="placesLI" 
-            style={{"list-style-type": "none"}}
+            style={{"listStyleType": "none"}}
             key={place.place_id} >
           <h4>{ place.name } <small>{ place.vicinity }</small></h4>
           <p>{ place.rating }</p>

--- a/app/reducers/reducer_jobs.js
+++ b/app/reducers/reducer_jobs.js
@@ -1,28 +1,28 @@
-const dummy = [{ 
-  jobtitle: 'Front-End', 
-  jobkey: '1', 
-  company: 'Google', 
-  formattedRelativeTime: '1 year ago', 
-  latitude:37.745951, 
-  longitude: -122.439421 
-},{ 
-  jobtitle: 'Back-End', 
-  jobkey: '2', 
-  company: 'MakerSquare', 
-  formattedRelativeTime: '15 days ago', 
-  latitude: 37.745, 
-  longitude: -122.439421 
-}, { 
-  jobtitle: 'Full-Stack', 
-  jobkey: '3', 
-  company: 'Go Daddy', 
-  formattedRelativeTime: '2 months ago',
-  latitude: 37.743, 
-  longitude: -122.419421 
-}];
+// const dummy = [{ 
+//   jobtitle: 'Front-End', 
+//   jobkey: '1', 
+//   company: 'Google', 
+//   formattedRelativeTime: '1 year ago', 
+//   latitude:37.745951, 
+//   longitude: -122.439421 
+// },{ 
+//   jobtitle: 'Back-End', 
+//   jobkey: '2', 
+//   company: 'MakerSquare', 
+//   formattedRelativeTime: '15 days ago', 
+//   latitude: 37.745, 
+//   longitude: -122.439421 
+// }, { 
+//   jobtitle: 'Full-Stack', 
+//   jobkey: '3', 
+//   company: 'Go Daddy', 
+//   formattedRelativeTime: '2 months ago',
+//   latitude: 37.743, 
+//   longitude: -122.419421 
+// }];
 
 
-export default (state = dummy, action) => {
+export default (state = [], action) => {
   switch(action.type) {
     case 'FETCH_JOBS':
       // console.log(`Action ${action} on Jobs Reducer.`);


### PR DESCRIPTION
- Implement logic to initially render the job body info in components/results_page.js.
- Convert style to camel case in containers/places_list_container.js.
- Remove unnecessary comments in reducers/reducer_jobs.js.
