### PR TITLE
config: Include RedisDB configuration on Express backend

### DIFF
--- a/server/controllers/getJob.js
+++ b/server/controllers/getJob.js
@@ -31,7 +31,7 @@ exports.post = (req, res) => {
     return;
   }
 
-  redis.del(key);
+  // redis.del(key);
 
   /*
    * Return data from cache if exists

--- a/server/controllers/getPlace.js
+++ b/server/controllers/getPlace.js
@@ -23,7 +23,7 @@ exports.post = (req, res) => {
     key = JSON.stringify(reqBody).toLowerCase();
   }
 
-  redis.del(key);
+  // redis.del(key);
 
   req.check('coordinate.lat', 'Latitude is required.').notEmpty();
   req.check('coordinate.long', 'Longitude is required.').notEmpty();

--- a/server/controllers/getRestaurant.js
+++ b/server/controllers/getRestaurant.js
@@ -26,7 +26,7 @@ exports.post = (req, res) => {
     key = JSON.stringify(reqBody).toLowerCase();
   }
 
-  redis.del(key);
+  // redis.del(key);
 
   req.check('city', 'City is required.').notEmpty();
   req.check('coordinate.latitude', 'Latitude is required.').notEmpty();

--- a/server/controllers/scrapeDetail.js
+++ b/server/controllers/scrapeDetail.js
@@ -1,3 +1,4 @@
+'use strict';
 const scrapeDetail = require('../models/details');
 const redisClient = require('redis').createClient;
 const redis = redisClient(6379, 'localhost');
@@ -17,7 +18,7 @@ exports.post = (req, res) => {
     key = JSON.stringify(reqBody).toLowerCase();
   }
 
-  redis.del(key);
+  // redis.del(key);
 
   redis.get(key, function(err, result) {
 

--- a/server/router.js
+++ b/server/router.js
@@ -4,7 +4,7 @@ const app = express();
 const request = require('request');
 const bodyParser = require('body-parser');
 const session = require('express-session');
-// const RedisStore = require('connect-redis')(session);
+const RedisStore = require('connect-redis')(session);
 const lusca = require('lusca');
 const expressValidator = require('express-validator');
 
@@ -28,7 +28,7 @@ app.use(session({
   name: 'Express Session Token',
   resave: true,
   saveUninitialized: true,
-  // store: new RedisStore()
+  store: new RedisStore()
 }));
 
 app.use(function (req, res, next) {


### PR DESCRIPTION
### Summary of Changes

- Having finally been in Beta long enough for some alpha trials to go through, it seems RedisDB (or, Redis-Server, rather) is available to run on Mac OS Sierra (Public Beta). Throughout the lifetime of this project's existence to this point, my machine has been unable to work with Redis (locally) and, consequently, required some unfortunate modifications in Node's configuration. Namely, I was unable to cache queried API data (as is the intent behind the use of this DB) and, effectively, had to run the project without it. (My apologies, team, for being the single biggest drain on our query limits). As of now, this issue should be no longer, and my server configuration (at least, as it exists in the present PR) should mirror that of my collaborators.